### PR TITLE
Add network interface parameter to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,25 +94,26 @@ make setup && make
 ./bin/crux
 
 Usage of ./bin/crux:
-      crux.config              Optional config file
-      --alwayssendto string    List of public keys for nodes to send all transactions too
-      --berkeleydb             Use Berkeley DB for working with an existing Constellation data store [experimental]
-      --generate-keys string   Generate a new keypair
-      --grpc                   Use gRPC server (default true)
-      --grpcport int           The local port to listen on for JSON extensions of gRPC (default -1)
-      --othernodes string      "Boot nodes" to connect to to discover the network
-      --port int               The local port to listen on (default -1)
-      --privatekeys string     Private keys hosted by this node
-      --publickeys string      Public keys hosted by this node
-      --socket string          IPC socket to create for access to the Private API (default "crux.ipc")
-      --storage string         Database storage file name (default "crux.db")
-      --tls                    Use TLS to secure HTTP communications
-      --tlsservercert string   The server certificate to be used
-      --tlsserverkey string    The server private key
-      --url string             The URL to advertise to other nodes (reachable by them)
-  -v, --v int                  Verbosity level of logs (shorthand) (default 1)
-      --verbosity int          Verbosity level of logs (default 1)
-      --workdir string         The folder to put stuff in (default: .) (default ".")
+      crux.config               Optional config file
+      --alwayssendto string     List of public keys for nodes to send all transactions too
+      --berkeleydb              Use Berkeley DB for working with an existing Constellation data store [experimental]
+      --generate-keys string    Generate a new keypair
+      --grpc                    Use gRPC server (default true)
+      --grpcport int            The local port to listen on for JSON extensions of gRPC (default -1)
+      --networkinterface string The network interface to bind the server to (default "localhost")
+      --othernodes string       "Boot nodes" to connect to to discover the network
+      --port int                The local port to listen on (default -1)
+      --privatekeys string      Private keys hosted by this node
+      --publickeys string       Public keys hosted by this node
+      --socket string           IPC socket to create for access to the Private API (default "crux.ipc")
+      --storage string          Database storage file name (default "crux.db")
+      --tls                     Use TLS to secure HTTP communications
+      --tlsservercert string    The server certificate to be used
+      --tlsserverkey string     The server private key
+      --url string              The URL to advertise to other nodes (reachable by them)
+  -v, --v int                   Verbosity level of logs (shorthand) (default 1)
+      --verbosity int           Verbosity level of logs (default 1)
+      --workdir string          The folder to put stuff in (default: .) (default ".")
 ``` 
 
 ## How does it work?

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ const (
 	BerkeleyDb   = "berkeleydb"
 	UseGRPC      = "grpc"
 	GrpcJsonPort = "grpcport"
+	NetworkInterface = "networkinterface"
 
 	Tls             = "tls"
 	TlsServerChain  = "tlsserverchain"
@@ -63,6 +64,7 @@ func InitFlags() {
 	flag.String(TlsServerCert, "", "The server certificate to be used")
 	flag.String(TlsServerKey, "", "The server private key")
 	flag.Int(GrpcJsonPort, -1, "The local port to listen on for JSON extensions of gRPC")
+	flag.String(NetworkInterface, "localhost", "The network interface to bind the server to")
 
 	// storage not currently supported as we use LevelDB
 

--- a/crux.go
+++ b/crux.go
@@ -139,7 +139,8 @@ func main() {
 		tlsKeyFile = path.Join(workDir, servKey)
 	}
 	grpcJsonport := config.GetInt(config.GrpcJsonPort)
-	_, err = server.Init(enc, port, ipcPath, grpc, grpcJsonport, tls, tlsCertFile, tlsKeyFile)
+	networkInterface := config.GetString(config.NetworkInterface)
+	_, err = server.Init(enc, networkInterface, port, ipcPath, grpc, grpcJsonport, tls, tlsCertFile, tlsKeyFile)
 	if err != nil {
 		log.Fatalf("Error starting server: %v\n", err)
 	}

--- a/docker/crux/start.sh
+++ b/docker/crux/start.sh
@@ -2,5 +2,5 @@
 
 echo $CRUX_PUB >> key.pub
 echo $CRUX_PRIV >> key.priv
-CMD="./bin/crux --url=http://$OWN_URL:$PORT/ --port=$PORT --publickeys=key.pub --privatekeys=key.priv --othernodes=$OTHER_NODES --verbosity=3"
+CMD="./bin/crux --url=http://$OWN_URL:$PORT/ --port=$PORT --networkinterface 0.0.0.0 --publickeys=key.pub --privatekeys=key.priv --othernodes=$OTHER_NODES --verbosity=3"
 $CMD >> "crux.log" 2>&1

--- a/docker/quorum-crux/crux-start.sh
+++ b/docker/quorum-crux/crux-start.sh
@@ -8,7 +8,7 @@ mkdir -p qdata/logs
 echo $CRUX_PUB >> "$DDIR/tm.pub"
 echo $CRUX_PRIV >> "$DDIR/tm.key"
 rm -f "$DDIR/tm.ipc"
-CMD="crux --url=http://$OWN_URL:$PORT/ --port=$PORT --workdir=$DDIR --socket=tm.ipc --publickeys=tm.pub --privatekeys=tm.key --othernodes=$OTHER_NODES --verbosity=3"
+CMD="crux --url=http://$OWN_URL:$PORT/ --port=$PORT --networkinterface 0.0.0.0 --workdir=$DDIR --socket=tm.ipc --publickeys=tm.pub --privatekeys=tm.key --othernodes=$OTHER_NODES --verbosity=3"
 $CMD >> "qdata/logs/crux.log" 2>&1 &
 
 DOWN=true

--- a/server/server.go
+++ b/server/server.go
@@ -75,20 +75,20 @@ func requestLogger(handler http.Handler) http.Handler {
 }
 
 // Init initializes a new TransactionManager instance.
-func Init(enc Enclave, port int, ipcPath string, grpc bool, grpcJsonPort int, tls bool, certFile, keyFile string) (TransactionManager, error) {
+func Init(enc Enclave, networkInterface string, port int, ipcPath string, grpc bool, grpcJsonPort int, tls bool, certFile, keyFile string) (TransactionManager, error) {
 	tm := TransactionManager{Enclave: enc}
 	var err error
 	if grpc == true {
-		err = tm.startRpcServer(port, grpcJsonPort, ipcPath, tls, certFile, keyFile)
+		err = tm.startRpcServer(networkInterface, port, grpcJsonPort, ipcPath, tls, certFile, keyFile)
 
 	} else {
-		err = tm.startHttpserver(port, ipcPath, tls, certFile, keyFile)
+		err = tm.startHttpserver(networkInterface, port, ipcPath, tls, certFile, keyFile)
 	}
 
 	return tm, err
 }
 
-func (tm *TransactionManager) startHttpserver(port int, ipcPath string, tls bool, certFile, keyFile string) error {
+func (tm *TransactionManager) startHttpserver(networkInterface string, port int, ipcPath string, tls bool, certFile, keyFile string) error {
 	httpServer := http.NewServeMux()
 	httpServer.HandleFunc(upCheck, tm.upcheck)
 	httpServer.HandleFunc(version, tm.version)
@@ -96,7 +96,7 @@ func (tm *TransactionManager) startHttpserver(port int, ipcPath string, tls bool
 	httpServer.HandleFunc(resend, tm.resend)
 	httpServer.HandleFunc(partyInfo, tm.partyInfo)
 
-	serverUrl := "localhost:" + strconv.Itoa(port)
+	serverUrl := networkInterface + ":" + strconv.Itoa(port)
 	if tls {
 		err := CheckCertFiles(certFile, keyFile)
 		if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -151,7 +151,7 @@ func TestGRPCSend(t *testing.T) {
 	}
 	expected := chimera.SendResponse{Key: payload}
 
-	freePort, err := GetFreePort()
+	freePort, err := GetFreePort("localhost")
 	if err != nil {
 		log.Fatalf("failed to find a free port to start gRPC REST server: %s", err)
 	}
@@ -216,7 +216,7 @@ func TestGRPCReceive(t *testing.T) {
 		},
 	}
 	expected := chimera.ReceiveResponse{Payload: payload}
-	freePort, err := GetFreePort()
+	freePort, err := GetFreePort("localhost")
 	if err != nil {
 		log.Fatalf("failed to find a free port to start gRPC REST server: %s", err)
 	}
@@ -510,7 +510,7 @@ func testRunPartyInfo(t *testing.T, pi api.PartyInfo) {
 
 func InitgRPCServer(t *testing.T, grpc bool, port int) string {
 	ipcPath, err := ioutil.TempDir("", "TestInitIpc")
-	tm, err := Init(&MockEnclave{}, port, ipcPath, grpc, -1, false, "", "")
+	tm, err := Init(&MockEnclave{}, "localhost", port, ipcPath, grpc, -1, false, "", "")
 
 	if err != nil {
 		t.Errorf("Error starting server: %v\n", err)
@@ -554,7 +554,7 @@ func TestInit(t *testing.T) {
 		t.Error(err)
 	}
 	certFile, keyFile := "../enclave/testdata/cert/server.crt", "../enclave/testdata/cert/server.key"
-	tm, err := Init(enc, 9001, ipcPath, false, -1, true, certFile, keyFile)
+	tm, err := Init(enc, "localhost", 9001, ipcPath, false, -1, true, certFile, keyFile)
 	if err != nil {
 		t.Errorf("Error starting server: %v\n", err)
 	}


### PR DESCRIPTION
Make it possible to bind to 0.0.0.0 instead of localhost.

Useful to expose ports with Docker.