### PR TITLE
Better verbosity settings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ const (
 
 	GenerateKeys = "generate-keys"
 
-	BerkeleyDb   = "berkeleydb"
-	UseGRPC      = "grpc"
-	GrpcJsonPort = "grpcport"
+	BerkeleyDb       = "berkeleydb"
+	UseGRPC          = "grpc"
+	GrpcJsonPort     = "grpcport"
 	NetworkInterface = "networkinterface"
 
 	Tls             = "tls"
@@ -56,7 +56,7 @@ func InitFlags() {
 	flag.Bool(BerkeleyDb, false,
 		"Use Berkeley DB for working with an existing Constellation data store [experimental]")
 
-	flag.Int(Verbosity, 1, "Verbosity level of logs")
+	flag.Int(Verbosity, 1, "Verbosity level of logs (0=fatal, 1=warn, 2=info, 3=debug)")
 	flag.Int(VerbosityShorthand, 1, "Verbosity level of logs (shorthand)")
 	flag.String(AlwaysSendTo, "", "List of public keys for nodes to send all transactions too")
 	flag.Bool(UseGRPC, true, "Use gRPC server")

--- a/crux.go
+++ b/crux.go
@@ -50,7 +50,7 @@ func main() {
 		level = log.WarnLevel
 	case 2:
 		level = log.InfoLevel
-	case 3:
+	default:
 		level = log.DebugLevel
 	}
 	log.SetLevel(level)


### PR DESCRIPTION
I had some confusion around logging levels, mostly coming from other Go software like geth where verbosity goes up to 5 or 6. Submitting some small user experience improvements to verbosity handling that would have made my life easier.

- Include verbosity levels in help printout: I had to dig through source code to figure out my verbosity options
- Include a default statement in the verbosity switch: Providing behavior more in line with what a user specifying a high verbosity is likely to want. Lack of a default statement led to zero-valued defaults being used which led to the lowest possible logging level, despite the fact that being in the default case implies the user wants a high verbosity.